### PR TITLE
Remove unused command from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,3 @@
 
 conda_env:
 	bash devtools/create_env.sh
-
-conda_env_arc:
-	bash devtools/create_env_arc.sh


### PR DESCRIPTION
`arc_env` and `ts_gcn`are separate conda environments