### PR TITLE
Update devtools scripts to use conda activate

### DIFF
--- a/devtools/create_env.sh
+++ b/devtools/create_env.sh
@@ -67,7 +67,7 @@ echo "Running: conda env create -f environment.yml"
 conda env create -f environment.yml
 
 # activate the environment to install torch-geometric
-source activate ts_gcn
+conda activate ts_gcn
 
 echo "Installing PyTorch with requested CUDA version..."
 echo "Running: conda install pytorch torchvision $CUDA -c pytorch"

--- a/devtools/create_env_cpu.sh
+++ b/devtools/create_env_cpu.sh
@@ -28,7 +28,7 @@ echo "Running: conda env create -f environment.yml"
 conda env create -f travis_environment.yml
 
 # activate the environment to install torch-geometric
-source activate ts_gcn
+conda activate ts_gcn
 
 echo "Installing torch-geometric..."
 echo "Using CUDA version: $CUDA_VERSION"


### PR DESCRIPTION
Previously used `source activate` to activate the environment and install pytorch dependencies