### PR TITLE
Update devtools gh actions

### DIFF
--- a/devtools/create_env.sh
+++ b/devtools/create_env.sh
@@ -67,6 +67,8 @@ echo "Running: conda env create -f environment.yml"
 conda env create -f environment.yml
 
 # activate the environment to install torch-geometric
+CONDA_BASE=$(conda info --base)
+source $CONDA_BASE/etc/profile.d/conda.sh
 conda activate ts_gcn
 
 echo "Installing PyTorch with requested CUDA version..."

--- a/devtools/create_env_cpu.sh
+++ b/devtools/create_env_cpu.sh
@@ -31,7 +31,8 @@ conda env create -f travis_environment.yml
 echo "Checking which python"
 which python
 export PATH=$CONDA_PREFIX/bin:$PATH
-conda init bash
+CONDA_BASE=$(conda info --base)
+source $CONDA_BASE/etc/profile.d/conda.sh
 conda activate ts_gcn
 echo "Checking which python"
 which python

--- a/devtools/create_env_cpu.sh
+++ b/devtools/create_env_cpu.sh
@@ -28,7 +28,12 @@ echo "Running: conda env create -f environment.yml"
 conda env create -f travis_environment.yml
 
 # activate the environment to install torch-geometric
+echo "Checking which python"
+which python
+export PATH=$CONDA_PREFIX/bin:$PATH
 source activate ts_gcn
+echo "Checking which python"
+which python
 
 echo "Installing torch-geometric..."
 echo "Using CUDA version: $CUDA_VERSION"

--- a/devtools/create_env_cpu.sh
+++ b/devtools/create_env_cpu.sh
@@ -28,7 +28,7 @@ echo "Running: conda env create -f environment.yml"
 conda env create -f travis_environment.yml
 
 # activate the environment to install torch-geometric
-conda activate ts_gcn
+source activate ts_gcn
 
 echo "Installing torch-geometric..."
 echo "Using CUDA version: $CUDA_VERSION"

--- a/devtools/create_env_cpu.sh
+++ b/devtools/create_env_cpu.sh
@@ -31,7 +31,8 @@ conda env create -f travis_environment.yml
 echo "Checking which python"
 which python
 export PATH=$CONDA_PREFIX/bin:$PATH
-source activate ts_gcn
+conda init bash
+conda activate ts_gcn
 echo "Checking which python"
 which python
 


### PR DESCRIPTION
Previously, `source activate ts_gcn` could properly activate the environment and the bash scripts in ARC and TS-GCN worked fine, as seen by the passing tests from this ARC [PR](https://github.com/ReactionMechanismGenerator/ARC/pull/438). Upon moving ARC to GitHub actions, `source activate` starting giving an error. This PR properly initializes conda so that `conda activate ts_gcn` does not error.